### PR TITLE
Fix Node.js capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # spotifyplay
-Playing with Spotify API with node.js
+Playing with Spotify API with Node.js


### PR DESCRIPTION
## Summary
- correct Node.js capitalization in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ca988854833196a5598d93e9e989