### PR TITLE
Fix server startup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # spotifyplay
 Playing with Spotify API with node.js
+
+## Usage
+
+Install [Node.js](https://nodejs.org/) and run the server with:
+
+```bash
+node spotify.js
+```
+
+The server listens on the port defined in the `PORT` environment variable, or
+`8080` by default.

--- a/spotify.js
+++ b/spotify.js
@@ -1,6 +1,19 @@
-var http = require('http');
+const http = require('http');
 
-http.createServer(function (req, res) {
-    res.writeHead(200, {'Content-Type': 'text/html'});
+const PORT = process.env.PORT || 8080;
+
+const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
     res.end('Hello World!');
-}).listen(8080);
+});
+
+server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});
+
+server.on('error', err => {
+    console.error(`Failed to start server: ${err.message}`);
+    process.exit(1);
+});
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- make server port configurable with an env variable
- log port on startup and report startup errors
- document how to run the server

## Testing
- `node spotify.js`

------
https://chatgpt.com/codex/tasks/task_e_6848c9e73a7083318623f673f1aa865d